### PR TITLE
test with river 3.0.0 rc1. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@
 
 allprojects {
 	ext {
-		riverVersion = "3.0"
+		riverVersion = "3.0.0"
 		riverHome = "${rootProject.projectDir.path}/apache-river-dist/apache-river-${riverVersion}"
 	}	
 }
@@ -36,9 +36,15 @@ subprojects {
     }
 
     dependencies {
-        river_platform "org.apache.river:start:${riverVersion}"
-        river_platform "net.jini:jsk-platform:${riverVersion}"
-        river_platform "net.jini:groovy-config:${riverVersion}"
+        //river_platform "org.apache.river:start:${riverVersion}"
+        river_platform files("${riverHome}/lib/start.jar")
+
+        //river_platform "net.jini:jsk-platform:${riverVersion}"
+        river_platform files("${riverHome}/lib/jsk-platform.jar")
+        river_platform files("${riverHome}/lib/jsk-resources.jar")
+
+        //river_platform "net.jini:groovy-config:${riverVersion}"
+        river_platform files("${riverHome}/lib/groovy-config.jar")
     }
 
     compileJava.options.encoding = 'UTF-8'

--- a/hello-service/build.gradle
+++ b/hello-service/build.gradle
@@ -24,8 +24,16 @@ configurations {
 }
 
 dependencies {
-	compile project(":hello-api")
-	compile "net.jini:jsk-lib:${riverVersion}"
+    compile project(":hello-api")
+
+    //compile "net.jini:jsk-lib:${riverVersion}"
+    compile files("${riverHome}/lib/jsk-lib.jar")
+    compile files("${riverHome}/lib/jsk-platform.jar")
+    compile files("${riverHome}/lib/jsk-resources.jar")
+
+    compile files("${riverHome}/lib/groovy-config.jar")
+    compile "org.codehaus.groovy:groovy:2.4.5"
+
     testCompile "junit:junit:4.12"
 }
 

--- a/hello-webapp-client/build.gradle
+++ b/hello-webapp-client/build.gradle
@@ -20,8 +20,13 @@ apply plugin: 'java'
 apply plugin: 'war'
 	
 dependencies {
-	compile project(":hello-api")
-	compile "net.jini:jsk-lib:${riverVersion}"		
+    compile project(":hello-api")
+
+    //compile "net.jini:jsk-lib:${riverVersion}"
+    compile files("${riverHome}/lib/jsk-lib.jar")
+    compile files("${riverHome}/lib/jsk-platform.jar")
+    compile files("${riverHome}/lib/jsk-resources.jar")
+
     compile "javax:javaee-web-api:6.0"
 }
 


### PR DESCRIPTION
Not intended for merge! To test, copy contents of: [apache-river-3.0.0-bin.tar.gz](http://people.apache.org/~peter_firmstone/apache-river-3.0.0-bin.tar.gz) to: ${rootProject.projectDir.path}/apache-river-dist/apache-river-3.0.0.  

I made a guess at the groovy dependency. 

I get the following test failure: GreeterServiceTest.java:68

```
java.lang.AssertionError
    at org.junit.Assert.fail(Assert.java:86)
    at org.junit.Assert.assertTrue(Assert.java:41)
    at org.junit.Assert.assertTrue(Assert.java:52)
    at org.apache.river.examples.hello.service.GreeterServiceTest.testGreeterService(GreeterServiceTest.java:68)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:606)
    at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
    at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
    at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
    at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
    at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
    at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
    at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
    at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
    at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
    at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
    at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
    at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
    at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecuter.runTestClass(JUnitTestClassExecuter.java:105)
    at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecuter.execute(JUnitTestClassExecuter.java:56)
    at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassProcessor.processTestClass(JUnitTestClassProcessor.java:64)
    at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.processTestClass(SuiteTestClassProcessor.java:50)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:606)
    at org.gradle.messaging.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:35)
    at org.gradle.messaging.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
    at org.gradle.messaging.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:32)
    at org.gradle.messaging.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:93)
    at com.sun.proxy.$Proxy2.processTestClass(Unknown Source)
    at org.gradle.api.internal.tasks.testing.worker.TestWorker.processTestClass(TestWorker.java:106)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:606)
    at org.gradle.messaging.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:35)
    at org.gradle.messaging.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
    at org.gradle.messaging.remote.internal.hub.MessageHub$Handler.run(MessageHub.java:360)
    at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:54)
    at org.gradle.internal.concurrent.StoppableExecutorImpl$1.run(StoppableExecutorImpl.java:40)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
    at java.lang.Thread.run(Thread.java:745)
```

Any idea what I'm missing?

Thanks!

PS: Where do the river poms get created? And are they available for v3?
